### PR TITLE
Fix bug 995 - "QDeclarativeView.itemAt returns faulty reference. (leading

### DIFF
--- a/generator/cppgenerator.cpp
+++ b/generator/cppgenerator.cpp
@@ -3518,7 +3518,7 @@ void CppGenerator::writeClassRegister(QTextStream& s, const AbstractMetaClass* m
 
     // Set typediscovery struct or fill the struct of another one
     if (metaClass->isPolymorphic() && metaClass->baseClass()) {
-        s << INDENT << "Shiboken::ObjectType::setTypeDiscoveryFunction(&" << cpythonTypeName(metaClass);
+        s << INDENT << "Shiboken::ObjectType::setTypeDiscoveryFunctionV2(&" << cpythonTypeName(metaClass);
         s << ", &" << cpythonBaseName(metaClass) << "_typeDiscovery);" << endl << endl;
     }
 
@@ -3616,22 +3616,14 @@ void CppGenerator::writeTypeDiscoveryFunction(QTextStream& s, const AbstractMeta
 {
     QString polymorphicExpr = metaClass->typeEntry()->polymorphicIdValue();
 
-    s << "static SbkObjectType* " << cpythonBaseName(metaClass) << "_typeDiscovery(void* cptr, SbkObjectType* instanceType)\n{" << endl;
+    s << "static void* " << cpythonBaseName(metaClass) << "_typeDiscovery(void* cptr, SbkObjectType* instanceType)\n{" << endl;
 
-    if (!metaClass->baseClass()) {
-        s << INDENT << "TypeResolver* typeResolver = TypeResolver::get(typeid(*reinterpret_cast< ::"
-          << metaClass->qualifiedCppName() << "*>(cptr)).name());" << endl;
-        s << INDENT << "if (typeResolver)" << endl;
-        {
-            Indentation indent(INDENT);
-            s << INDENT << "return reinterpret_cast<SbkObjectType*>(typeResolver->pythonType());" << endl;
-        }
-    } else if (!polymorphicExpr.isEmpty()) {
+    if (!polymorphicExpr.isEmpty()) {
         polymorphicExpr = polymorphicExpr.replace("%1", " reinterpret_cast< ::" + metaClass->qualifiedCppName() + "*>(cptr)");
         s << INDENT << " if (" << polymorphicExpr << ")" << endl;
         {
             Indentation indent(INDENT);
-            s << INDENT << "return &" << cpythonTypeName(metaClass) << ';' << endl;
+            s << INDENT << "return cptr;" << endl;
         }
     } else if (metaClass->isPolymorphic()) {
         AbstractMetaClassList ancestors = getAllAncestors(metaClass);
@@ -3640,10 +3632,10 @@ void CppGenerator::writeTypeDiscoveryFunction(QTextStream& s, const AbstractMeta
                 continue;
             if (ancestor->isPolymorphic()) {
                 s << INDENT << "if (instanceType == reinterpret_cast<SbkObjectType*>(Shiboken::SbkType< ::"
-                            << ancestor->qualifiedCppName() << " >()) && dynamic_cast< ::" << metaClass->qualifiedCppName()
-                            << "*>(reinterpret_cast< ::"<< ancestor->qualifiedCppName() << "*>(cptr)))" << endl;
+                            << ancestor->qualifiedCppName() << " >()))" << endl;
                 Indentation indent(INDENT);
-                s << INDENT << "return &" << cpythonTypeName(metaClass) << ';' << endl;
+                s << INDENT << "return dynamic_cast< ::" << metaClass->qualifiedCppName()
+                            << "*>(reinterpret_cast< ::"<< ancestor->qualifiedCppName() << "*>(cptr));" << endl;
             } else {
                 ReportHandler::warning(metaClass->qualifiedCppName() + " inherits from a non polymorphic type ("
                                        + ancestor->qualifiedCppName() + "), type discovery based on RTTI is "

--- a/libshiboken/basewrapper.cpp
+++ b/libshiboken/basewrapper.cpp
@@ -593,14 +593,21 @@ const char* getOriginalName(SbkObjectType* self)
     return self->d->original_name;
 }
 
-void setTypeDiscoveryFunction(SbkObjectType* self, TypeDiscoveryFunc func)
+void setTypeDiscoveryFunctionV2(SbkObjectType* self, TypeDiscoveryFuncV2 func)
 {
     self->d->type_discovery = func;
 }
 
+void setTypeDiscoveryFunction(SbkObjectType* self, TypeDiscoveryFunc func)
+{
+    self->d->type_discovery = (TypeDiscoveryFuncV2)func;
+}
+
 TypeDiscoveryFunc getTypeDiscoveryFunction(SbkObjectType* self)
 {
-    return self->d->type_discovery;
+    // This is a illegal cast because the return value is different,
+    // but nobody ever used this function, so... =]
+    return (TypeDiscoveryFunc)self->d->type_discovery;
 }
 
 void copyMultimpleheritance(SbkObjectType* self, SbkObjectType* other)
@@ -979,7 +986,7 @@ PyObject* newObject(SbkObjectType* instanceType,
                 instanceType = reinterpret_cast<SbkObjectType*>(tr->pythonType());
         }
         if (!tr)
-            instanceType = BindingManager::instance().resolveType(cptr, instanceType);
+            instanceType = BindingManager::instance().resolveType(&cptr, instanceType);
     }
 
     SbkObject* self = reinterpret_cast<SbkObject*>(SbkObjectTpNew(reinterpret_cast<PyTypeObject*>(instanceType), 0, 0));

--- a/libshiboken/basewrapper.h
+++ b/libshiboken/basewrapper.h
@@ -64,6 +64,7 @@ typedef int* (*MultipleInheritanceInitFunction)(const void*);
  */
 typedef void* (*SpecialCastFunction)(void*, SbkObjectType*);
 typedef SbkObjectType* (*TypeDiscoveryFunc)(void*, SbkObjectType*);
+typedef void* (*TypeDiscoveryFuncV2)(void*, SbkObjectType*);
 
 typedef void* (*ExtendedToCppFunc)(PyObject*);
 typedef bool (*ExtendedIsConvertibleFunc)(PyObject*);
@@ -157,8 +158,9 @@ LIBSHIBOKEN_API void        setCastFunction(SbkObjectType* type, SpecialCastFunc
 LIBSHIBOKEN_API void        setOriginalName(SbkObjectType* self, const char* name);
 LIBSHIBOKEN_API const char* getOriginalName(SbkObjectType* self);
 
-LIBSHIBOKEN_API void        setTypeDiscoveryFunction(SbkObjectType* self, TypeDiscoveryFunc func);
-LIBSHIBOKEN_API TypeDiscoveryFunc getTypeDiscoveryFunction(SbkObjectType* self);
+LIBSHIBOKEN_API void setTypeDiscoveryFunctionV2(SbkObjectType* self, TypeDiscoveryFuncV2 func);
+LIBSHIBOKEN_API SBK_DEPRECATED(void setTypeDiscoveryFunction(SbkObjectType* self, TypeDiscoveryFunc func));
+LIBSHIBOKEN_API SBK_DEPRECATED(TypeDiscoveryFunc getTypeDiscoveryFunction(SbkObjectType* self));
 
 LIBSHIBOKEN_API void        copyMultimpleheritance(SbkObjectType* self, SbkObjectType* other);
 LIBSHIBOKEN_API void        setMultipleIheritanceFunction(SbkObjectType* self, MultipleInheritanceInitFunction func);

--- a/libshiboken/basewrapper_p.h
+++ b/libshiboken/basewrapper_p.h
@@ -98,7 +98,7 @@ struct SbkObjectTypePrivate
 
     /// Special cast function, null if this class doesn't have multiple inheritance.
     SpecialCastFunction mi_specialcast;
-    TypeDiscoveryFunc type_discovery;
+    TypeDiscoveryFuncV2 type_discovery;
     /// Extended "isConvertible" function to be used when a conversion operator is defined in another module.
     ExtendedIsConvertibleFunc ext_isconvertible;
     /// Extended "toCpp" function to be used when a conversion operator is defined in another module.

--- a/libshiboken/bindingmanager.h
+++ b/libshiboken/bindingmanager.h
@@ -49,7 +49,20 @@ public:
     PyObject* getOverride(const void* cptr, const char* methodName);
 
     void addClassInheritance(SbkObjectType* parent, SbkObjectType* child);
-    SbkObjectType* resolveType(void* cptr, SbkObjectType* type);
+    /**
+     * \deprecated Use \fn resolveType(void**, SbkObjectType*), this version is broken when used with multiple inheritance
+     *             because the \p cptr pointer of the discovered type may be different of the given \p cptr in case
+     *             of multiple inheritance
+     */
+    SBK_DEPRECATED(SbkObjectType* resolveType(void* cptr, SbkObjectType* type));
+    /**
+     * Try to find the correct type of *cptr knowing that it's at least of type \p type.
+     * In case of multiple inheritance this function may change the contents of cptr.
+     * \param cptr a pointer to a pointer to the instance of type \p type
+     * \param type type of *cptr
+     * \warning This function is slow, use it only as last resort.
+     */
+    SbkObjectType* resolveType(void** cptr, SbkObjectType* type);
 
     std::set<SbkObject*> getAllPyObjects();
 


### PR DESCRIPTION
Fix bug 995 - "QDeclarativeView.itemAt returns faulty reference. (leading to SEGFAULT)"
