### PR TITLE
Fixes writeReturnValueHeuristics to not mess with constructors.

### DIFF
--- a/generator/cppgenerator.cpp
+++ b/generator/cppgenerator.cpp
@@ -4187,6 +4187,7 @@ void CppGenerator::writeReturnValueHeuristics(QTextStream& s, const AbstractMeta
         || !func->ownerClass()
         || !type
         || func->isStatic()
+        || func->isConstructor()
         || !func->typeReplaced(0).isEmpty()) {
         return;
     }

--- a/generator/shibokengenerator.cpp
+++ b/generator/shibokengenerator.cpp
@@ -864,7 +864,7 @@ bool ShibokenGenerator::isWrapperType(const AbstractMetaType* metaType)
 
 bool ShibokenGenerator::isPointerToWrapperType(const AbstractMetaType* type)
 {
-    return isObjectType(type) || type->isValuePointer();
+    return (isObjectType(type) && type->indirections() == 1) || type->isValuePointer();
 }
 
 bool ShibokenGenerator::shouldDereferenceArgumentPointer(const AbstractMetaArgument* arg)


### PR DESCRIPTION
Also fixes isWrapperType to avoid erring when the type is an
object type passed as value.
