### PR TITLE
generator: function must return a value

### DIFF
--- a/generator/cppgenerator.cpp
+++ b/generator/cppgenerator.cpp
@@ -3914,6 +3914,7 @@ void CppGenerator::finishGeneration()
         s << "static int " << moduleName() << "_moduleTraverse(PyObject*, visitproc, void *)" << endl
           << "{" << endl
           << INDENT << "PySide::runCleanupFunctions();" << endl
+          << INDENT << "return 0;" << endl
           << "}" << endl << endl;
     }
 


### PR DESCRIPTION
Fix msvc9 compile error.

Signed-off-by: Paulo Alcantara pcacjr@gmail.com
