### PR TITLE
Remove warning of struct forward declared as class.

### DIFF
--- a/libshiboken/autodecref.h
+++ b/libshiboken/autodecref.h
@@ -26,7 +26,7 @@
 #include "sbkpython.h"
 #include "shibokenmacros.h"
 
-class SbkObject;
+struct SbkObject;
 namespace Shiboken
 {
 


### PR DESCRIPTION
sbkObject is a struct, but was forward declared as a class.