### PR TITLE
Fixes build failure with clang and libc++ on Mac OS X Mavericks.

### DIFF
--- a/libshiboken/CMakeLists.txt
+++ b/libshiboken/CMakeLists.txt
@@ -11,8 +11,10 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/sbkversion.h.in"
                "${CMAKE_CURRENT_BINARY_DIR}/sbkversion.h" @ONLY)
 
 #Find installed sparsehash
-find_path(SPARSEHASH_INCLUDE_PATH sparseconfig.h PATH_SUFFIXES "/google/sparsehash")
-if(SPARSEHASH_INCLUDE_PATH)
+find_package(PkgConfig)
+pkg_check_modules(SPARSEHASH libsparsehash)
+if(SPARSEHASH_FOUND)
+    set(SPARSEHASH_INCLUDE_PATH ${SPARSEHASH_INCLUDE_DIRS})
     message(STATUS "Using system hash found in: ${SPARSEHASH_INCLUDE_PATH}")
 else()
     set(SPARSEHASH_INCLUDE_PATH ${CMAKE_SOURCE_DIR}/ext/sparsehash)

--- a/tests/libsample/simplefile.cpp
+++ b/tests/libsample/simplefile.cpp
@@ -90,13 +90,13 @@ bool
 SimpleFile::exists() const
 {
     std::ifstream ifile(p->m_filename);
-    return ifile;
+    return bool(ifile);
 }
 
 bool
 SimpleFile::exists(const char* filename)
 {
     std::ifstream ifile(filename);
-    return ifile;
+    return bool(ifile);
 }
 


### PR DESCRIPTION
OS X Mavericks defaults to libc++, which doesn't include the TR1 components required by the bundled google-sparsehash. We just have to use a newer version.
