### PR TITLE
Override dead bindings when registering a new binding.

### DIFF
--- a/libshiboken/bindingmanager.cpp
+++ b/libshiboken/bindingmanager.cpp
@@ -140,9 +140,7 @@ void BindingManager::BindingManagerPrivate::releaseWrapper(void* cptr)
 void BindingManager::BindingManagerPrivate::assignWrapper(SbkObject* wrapper, const void* cptr)
 {
     assert(cptr);
-    WrapperMap::iterator iter = wrapperMapper.find(cptr);
-    if (iter == wrapperMapper.end())
-        wrapperMapper.insert(std::make_pair(cptr, wrapper));
+    wrapperMapper[cptr] = wrapper;
 }
 
 BindingManager::BindingManager()

--- a/shibokenmodule/typesystem_shiboken.xml
+++ b/shibokenmodule/typesystem_shiboken.xml
@@ -4,6 +4,7 @@
     <custom-type name="PyType" />
     <primitive-type name="bool" />
     <primitive-type name="unsigned long" />
+    <primitive-type name="size_t" />
     <add-function signature="isValid(PyObject*)" return-type="bool">
         <inject-code>
             bool isValid = Shiboken::Object::isValid(%1, false);
@@ -35,6 +36,15 @@
                     PyTuple_SET_ITEM(%PYARG_0, i, PyLong_FromVoidPtr(ptrs[i]));
             } else {
                 PyErr_SetString(PyExc_TypeError, "You need a shiboken-based type.");
+            }
+        </inject-code>
+   </add-function>
+
+   <add-function signature="getBinding(size_t)" return-type="PyObject *">
+        <inject-code>
+            %PYARG_0 = (PyObject*)Shiboken::BindingManager::instance().retrieveWrapper((void *)%1);
+            if(!%PYARG_0) {
+                PyErr_SetString(PyExc_ValueError, "No binding registered.");
             }
         </inject-code>
    </add-function>


### PR DESCRIPTION
This fixes the behavior observed in #74.

When a C++ object is deallocated, the BindingManager retains a binding that points from the C++ object to its Python wrapper. The binding is normally destroyed when the Python wrapper is freed. If a new C++ object is allocated at the same address (before the Python wrapper is freed), the new binding will not be registered.

This change ensures that the new binding will be registered even if the old Python wrapper has not been freed.

When the old Python wrapper is freed, it uses the Python wrapper's address to destroy the binding (not the C++ object's address), so it will not destroy the new binding.

(BindingManager would previously override old bindings. This was changed in commit 3b747443bde5752277aa9791adbfc1d32868689b without explaining why.)

Additionally, this change adds the method `shiboken.getBinding(cppAddress)` to the shiboken module to aid in debugging similar problems with the BindingManager.