### PR TITLE
segfault when including boost shared_ptr header (PYSIDE-218)

### DIFF
--- a/ApiExtractor/abstractmetabuilder.cpp
+++ b/ApiExtractor/abstractmetabuilder.cpp
@@ -220,6 +220,7 @@ void AbstractMetaBuilder::traverseOperatorFunction(FunctionModelItem item)
     bool firstArgumentIsSelf = true;
     bool unaryOperator = false;
 
+    if (arguments.size() == 0) return;
     baseoperandClass = argumentToClass(arguments.at(0));
 
     if (arguments.size() == 1) {


### PR DESCRIPTION
Without the patch the following line tries to access the first argument even if there is none :bomb:

For more information about this workaround please see https://bugreports.qt.io/browse/PYSIDE-218
