### PR TITLE
Fix building tests with GCC-6

### DIFF
--- a/tests/libsample/simplefile.cpp
+++ b/tests/libsample/simplefile.cpp
@@ -90,13 +90,13 @@ bool
 SimpleFile::exists() const
 {
     std::ifstream ifile(p->m_filename);
-    return ifile;
+    return static_cast<bool>(ifile);
 }
 
 bool
 SimpleFile::exists(const char* filename)
 {
     std::ifstream ifile(filename);
-    return ifile;
+    return static_cast<bool>(ifile);
 }
 


### PR DESCRIPTION
Building tests with GCC-6.3.0 fails with:

```
/var/tmp/portage/dev-python/shiboken-1.2.2/work/shiboken-1.2.2/tests/libsample/simplefile.cpp: In member function 'bool SimpleFile::exists() const':
/var/tmp/portage/dev-python/shiboken-1.2.2/work/shiboken-1.2.2/tests/libsample/simplefile.cpp:93:12: error: cannot convert 'std::ifstream {aka std::basic_ifstream<char>}' to 'bool' in return
     return ifile;
            ^~~~~
/var/tmp/portage/dev-python/shiboken-1.2.2/work/shiboken-1.2.2/tests/libsample/simplefile.cpp: In static member function 'static bool SimpleFile::exists(const char*)':
/var/tmp/portage/dev-python/shiboken-1.2.2/work/shiboken-1.2.2/tests/libsample/simplefile.cpp:100:12: error: cannot convert 'std::ifstream {aka std::basic_ifstream<char>}' to 'bool' in return
     return ifile;
            ^~~~~
```

Post C++11, implicit conversion to `bool` from an `istream` of `ostream` object is not allowed.