### PR TITLE
tests/libsample/simplefile.cpp: fix compilation error with gcc6

### DIFF
--- a/tests/libsample/simplefile.cpp
+++ b/tests/libsample/simplefile.cpp
@@ -90,13 +90,13 @@ bool
 SimpleFile::exists() const
 {
     std::ifstream ifile(p->m_filename);
-    return ifile;
+    return (bool)ifile;
 }
 
 bool
 SimpleFile::exists(const char* filename)
 {
     std::ifstream ifile(filename);
-    return ifile;
+    return (bool)ifile;
 }
 


### PR DESCRIPTION
c++11 requires explicit casting to bool in some cases.