### PR TITLE
Fix building with Python 3.9

### DIFF
--- a/libshiboken/sbkenum.cpp
+++ b/libshiboken/sbkenum.cpp
@@ -529,7 +529,9 @@ PyTypeObject* newTypeWithName(const char* name, const char* cppName)
     ::memset(type, 0, sizeof(SbkEnumType));
     Py_TYPE(type) = &SbkEnumType_Type;
     type->tp_basicsize = sizeof(SbkEnumObject);
+#ifndef IS_PY3K
     type->tp_print = &SbkEnumObject_print;
+#endif
     type->tp_repr = &SbkEnumObject_repr;
     type->tp_str = &SbkEnumObject_repr;
     type->tp_flags = Py_TPFLAGS_DEFAULT|Py_TPFLAGS_CHECKTYPES;


### PR DESCRIPTION
Fix building with Python 3.9 by not setting `tp_print` if building with Python 3.0 or later. According to the [Python docs](https://docs.python.org/3/c-api/typeobj.html) this slot has been unused since Python 3.0, was deprecated in 3.8 and removed altogether in 3.9.